### PR TITLE
feat: credit configurator improvements

### DIFF
--- a/contracts/interfaces/ICreditConfigurator.sol
+++ b/contracts/interfaces/ICreditConfigurator.sol
@@ -27,6 +27,8 @@ struct CreditManagerOpts {
     address degenNFT;
     /// @dev Whether the Credit Manager is connected to an expirable pool (and the CreditFacade is expirable)
     bool expirable;
+    /// @dev Whether to skip normal initialization - used for new Credit Configurators that are deployed for existing CMs
+    bool skipInit;
 }
 
 interface ICreditConfiguratorEvents {
@@ -47,6 +49,9 @@ interface ICreditConfiguratorEvents {
 
     /// @dev Emits when a 3rd-party contract is forbidden
     event ContractForbidden(address indexed protocol);
+
+    /// @dev Emits when a particular adapter for a target contract is forbidden
+    event AdapterForbidden(address indexed adapter);
 
     /// @dev Emits when debt principal limits are changed
     event LimitsUpdated(uint256 minBorrowedAmount, uint256 maxBorrowedAmount);
@@ -125,6 +130,12 @@ interface ICreditConfiguratorExceptions {
 
     /// @dev Thrown if attempting to forbid an adapter that is not allowed for the Credit Manager
     error ContractIsNotAnAllowedAdapterException();
+
+    /// @dev Thrown if attempting to forbid or migrate a target contract that is not allowed for the Credit Manager
+    error ContractIsNotAnAllowedTargetException();
+
+    /// @dev Thrown if attempting to set a migratable parameter that is already non-zero
+    error MigratableParameterAlreadySet();
 }
 
 interface ICreditConfigurator is
@@ -132,6 +143,16 @@ interface ICreditConfigurator is
     ICreditConfiguratorExceptions,
     IVersion
 {
+    //
+    // PARAMETER MIGRATION FUNCTIONS
+    //
+
+    /// @dev Migration function used to populate the new CC's allowedContractsSet based on the previous CC's values
+    /// @param allowedContractsPrev List of allowed contracts to migrate
+    /// @notice Only callable once
+    function migrateAllowedContractsSet(address[] calldata allowedContractsPrev)
+        external;
+
     //
     // STATE-CHANGING FUNCTIONS
     //
@@ -168,6 +189,11 @@ interface ICreditConfigurator is
     /// @dev Forbids contract as a target for calls from Credit Accounts
     /// @param targetContract Address of a contract to be forbidden
     function forbidContract(address targetContract) external;
+
+    /// @dev Forbids adapter (and only the adapter - the target contract is not affected)
+    /// @param adapter Address of adapter to disable
+    /// @notice Used to clean up orphaned adapters
+    function forbidAdapter(address adapter) external;
 
     /// @dev Sets borrowed amount limits in Credit Facade
     /// @param _minBorrowedAmount Minimum borrowed amount

--- a/contracts/test/config/CreditConfig.sol
+++ b/contracts/test/config/CreditConfig.sol
@@ -61,7 +61,8 @@ contract CreditConfig is DSTest, ICreditConfig {
                 maxBorrowedAmount: maxBorrowedAmount,
                 collateralTokens: getCollateralTokens(),
                 degenNFT: address(0),
-                expirable: false
+                expirable: false,
+                skipInit: false
             });
     }
 

--- a/contracts/test/credit/CreditConfigurator.t.sol
+++ b/contracts/test/credit/CreditConfigurator.t.sol
@@ -1667,6 +1667,7 @@ contract CreditConfiguratorTest is
             maxBorrowedAmount: uint128(150000 * WAD),
             collateralTokens: cTokens,
             degenNFT: address(0),
+            blacklistHelper: address(0),
             expirable: false,
             skipInit: true
         });

--- a/contracts/test/credit/CreditConfigurator.t.sol
+++ b/contracts/test/credit/CreditConfigurator.t.sol
@@ -364,7 +364,8 @@ contract CreditConfiguratorTest is
             maxBorrowedAmount: uint128(150000 * WAD),
             collateralTokens: cTokens,
             degenNFT: address(0),
-            expirable: false
+            expirable: false,
+            skipInit: false
         });
 
         creditManager = new CreditManager(address(cct.poolMock()));
@@ -795,10 +796,8 @@ contract CreditConfiguratorTest is
         evm.stopPrank();
     }
 
-    /// @dev [CC-14]: allowContract: adapter or contract could not be used twice
-    function test_CC_14_allowContract_reverts_for_creditManager_and_creditFacade_contracts()
-        public
-    {
+    /// @dev [CC-14]: allowContract: adapter could not be used twice
+    function test_CC_14_allowContract_adapter_cannot_be_used_twice() public {
         evm.startPrank(CONFIGURATOR);
 
         creditConfigurator.allowContract(
@@ -858,6 +857,40 @@ contract CreditConfiguratorTest is
         assertTrue(
             allowedContracts.includes(TARGET_CONTRACT),
             "Target contract wasnt found"
+        );
+    }
+
+    /// @dev [CC-15A]: allowContract removes existing adapter
+    function test_CC_15A_allowContract_removes_old_adapter_if_it_exists()
+        public
+    {
+        evm.prank(CONFIGURATOR);
+        creditConfigurator.allowContract(TARGET_CONTRACT, address(adapter1));
+
+        AdapterMock adapter2 = new AdapterMock(
+            address(creditManager),
+            TARGET_CONTRACT
+        );
+
+        evm.prank(CONFIGURATOR);
+        creditConfigurator.allowContract(TARGET_CONTRACT, address(adapter2));
+
+        assertEq(
+            creditManager.contractToAdapter(TARGET_CONTRACT),
+            address(adapter2),
+            "Incorrect adapter"
+        );
+
+        assertEq(
+            creditManager.adapterToContract(address(adapter2)),
+            TARGET_CONTRACT,
+            "Incorrect target contract for new adapter"
+        );
+
+        assertEq(
+            creditManager.adapterToContract(address(adapter1)),
+            address(0),
+            "Old adapter was not removed"
         );
     }
 
@@ -1514,7 +1547,7 @@ contract CreditConfiguratorTest is
     }
 
     /// @dev [CC-39]: removeEmergencyLiquidator works correctly and emits event
-    function test_CC_38_removeEmergencyLiquidator_works_correctly() public {
+    function test_CC_39_removeEmergencyLiquidator_works_correctly() public {
         evm.expectRevert(CallerNotConfiguratorException.selector);
         creditConfigurator.removeEmergencyLiquidator(DUMB_ADDRESS);
 
@@ -1531,5 +1564,81 @@ contract CreditConfiguratorTest is
             !creditManager.canLiquidateWhilePaused(DUMB_ADDRESS),
             "Credit manager emergency liquidator status incorrect"
         );
+    }
+
+    /// @dev [CC-40]: forbidAdapter works correctly and emits event
+    function test_CC_40_forbidAdapter_works_correctly() public {
+        evm.expectRevert(CallerNotConfiguratorException.selector);
+        creditConfigurator.forbidAdapter(DUMB_ADDRESS);
+
+        evm.prank(CONFIGURATOR);
+        creditConfigurator.allowContract(TARGET_CONTRACT, address(adapter1));
+
+        evm.expectEmit(true, false, false, false);
+        emit AdapterForbidden(address(adapter1));
+
+        evm.prank(CONFIGURATOR);
+        creditConfigurator.forbidAdapter(address(adapter1));
+
+        assertEq(
+            creditManager.adapterToContract(address(adapter1)),
+            address(0),
+            "Adapter to contract link was not removed"
+        );
+
+        assertEq(
+            creditManager.contractToAdapter(TARGET_CONTRACT),
+            address(adapter1),
+            "Contract to adapter link was removed"
+        );
+    }
+
+    /// @dev [CC-41]: migrateAllowedContractsSet works correctly
+    function test_CC_41_migrateAllowedContractsSet_works_correctly() public {
+        evm.prank(CONFIGURATOR);
+        creditConfigurator.allowContract(TARGET_CONTRACT, address(adapter1));
+
+        CollateralToken[] memory cTokens;
+
+        CreditManagerOpts memory creditOpts = CreditManagerOpts({
+            minBorrowedAmount: uint128(50 * WAD),
+            maxBorrowedAmount: uint128(150000 * WAD),
+            collateralTokens: cTokens,
+            degenNFT: address(0),
+            expirable: false,
+            skipInit: true
+        });
+
+        CreditConfigurator newCC = new CreditConfigurator(
+            creditManager,
+            creditFacade,
+            creditOpts
+        );
+
+        address[] memory allowedContracts = creditConfigurator
+            .allowedContracts();
+
+        {
+            address[] memory allowedContractsFalse = new address[](2);
+            allowedContractsFalse[0] = allowedContracts[0];
+            allowedContractsFalse[1] = DUMB_ADDRESS;
+
+            evm.expectRevert(ContractIsNotAnAllowedTargetException.selector);
+            evm.prank(CONFIGURATOR);
+            newCC.migrateAllowedContractsSet(allowedContractsFalse);
+        }
+
+        evm.prank(CONFIGURATOR);
+        newCC.migrateAllowedContractsSet(allowedContracts);
+
+        assertEq(
+            creditConfigurator.allowedContracts().length,
+            newCC.allowedContracts().length,
+            "Incorrect new allowed contracts array"
+        );
+
+        evm.expectRevert(MigratableParameterAlreadySet.selector);
+        evm.prank(CONFIGURATOR);
+        newCC.migrateAllowedContractsSet(allowedContracts);
     }
 }


### PR DESCRIPTION
Credit Configurator bug fixes and improvements:
1) `allowContract` will now correctly unlink the previous adapter for target contract, if it was set;
2) `migrateAllowedContractsSet` was added to move the allowed contracts set to new Credit Configurators, since it was previously only updated in `allowContract`, which would cause a discrepancy on updating the CC;
3) `skipInit` parameter added to CreditManagerOpts, to skip CM configuration with default parameters if a CC is deployed for an existing CM;