### PR TITLE
fix: fixed credit configurator and adapter bugs

### DIFF
--- a/contracts/adapters/AbstractAdapter.sol
+++ b/contracts/adapters/AbstractAdapter.sol
@@ -12,7 +12,6 @@ abstract contract AbstractAdapter is IAdapter {
     using Address for address;
 
     ICreditManagerV2 public immutable override creditManager;
-    address public immutable override creditFacade;
     address public immutable override targetContract;
 
     constructor(address _creditManager, address _targetContract) {
@@ -20,7 +19,6 @@ abstract contract AbstractAdapter is IAdapter {
             revert ZeroAddressException(); // F:[AA-2]
 
         creditManager = ICreditManagerV2(_creditManager); // F:[AA-1]
-        creditFacade = ICreditManagerV2(_creditManager).creditFacade(); // F:[AA-1]
         targetContract = _targetContract; // F:[AA-1]
     }
 
@@ -65,6 +63,8 @@ abstract contract AbstractAdapter is IAdapter {
         bool allowTokenIn,
         bool disableTokenIn
     ) internal returns (bytes memory result) {
+        address creditFacade = creditManager.creditFacade();
+
         uint256 balanceInBefore;
         uint256 balanceOutBefore;
 
@@ -89,6 +89,7 @@ abstract contract AbstractAdapter is IAdapter {
 
         _fastCheck(
             creditAccount,
+            creditFacade,
             tokenIn,
             tokenOut,
             balanceInBefore,
@@ -135,6 +136,8 @@ abstract contract AbstractAdapter is IAdapter {
         bool allowTokenIn,
         bool disableTokenIn
     ) internal returns (bytes memory result) {
+        address creditFacade = creditManager.creditFacade();
+
         uint256 balanceInBefore;
         uint256 balanceOutBefore;
 
@@ -159,6 +162,7 @@ abstract contract AbstractAdapter is IAdapter {
 
         _fastCheck(
             creditAccount,
+            creditFacade,
             tokenIn,
             tokenOut,
             balanceInBefore,
@@ -197,6 +201,7 @@ abstract contract AbstractAdapter is IAdapter {
     /// @dev Performs a fast check during ordinary adapter call, or skips
     /// it for multicalls (since a full collateral check is always performed after a multicall)
     /// @param creditAccount Credit Account for which the fast check is performed
+    /// @param creditFacade CreditFacade currently associated with CreditManager
     /// @param tokenIn Token that is spent by the operation
     /// @param tokenOut Token that is received as a result of operation
     /// @param balanceInBefore Balance of tokenIn before the operation
@@ -204,6 +209,7 @@ abstract contract AbstractAdapter is IAdapter {
     /// @param disableTokenIn Whether tokenIn needs to be disabled (required for multicalls, where the fast check is skipped)
     function _fastCheck(
         address creditAccount,
+        address creditFacade,
         address tokenIn,
         address tokenOut,
         uint256 balanceInBefore,
@@ -229,6 +235,8 @@ abstract contract AbstractAdapter is IAdapter {
     /// it for multicalls (since a full collateral check is always performed after a multicall)
     /// @param creditAccount Credit Account for which the full check is performed
     function _fullCheck(address creditAccount) internal {
+        address creditFacade = creditManager.creditFacade();
+
         if (msg.sender != creditFacade) {
             creditManager.fullCollateralCheck(creditAccount);
         }
@@ -241,6 +249,8 @@ abstract contract AbstractAdapter is IAdapter {
     /// @notice Used when new tokens are added on an account but no tokens are subtracted
     ///         (e.g., claiming rewards)
     function _checkAndOptimizeEnabledTokens(address creditAccount) internal {
+        address creditFacade = creditManager.creditFacade();
+
         if (msg.sender != creditFacade) {
             creditManager.checkAndOptimizeEnabledTokens(creditAccount);
         }

--- a/contracts/adapters/UniversalAdapter.sol
+++ b/contracts/adapters/UniversalAdapter.sol
@@ -19,9 +19,6 @@ contract UniversalAdapter is IUniversalAdapter {
     /// @dev The credit manager this universal adapter connects to
     ICreditManagerV2 public immutable override creditManager;
 
-    /// @dev The credit facade attached to the credit manager
-    address public immutable override creditFacade;
-
     AdapterType public constant _gearboxAdapterType = AdapterType.UNIVERSAL;
     uint16 public constant _gearboxAdapterVersion = 1;
 
@@ -29,9 +26,7 @@ contract UniversalAdapter is IUniversalAdapter {
     /// @param _creditManager Address of the Credit Manager
     constructor(address _creditManager) {
         if (_creditManager == address(0)) revert ZeroAddressException();
-
         creditManager = ICreditManagerV2(_creditManager);
-        creditFacade = ICreditManagerV2(_creditManager).creditFacade();
     }
 
     /// @dev Sets allowances to zero for the provided spender/token pairs, for msg.sender's CA

--- a/contracts/credit/CreditConfigurator.sol
+++ b/contracts/credit/CreditConfigurator.sol
@@ -83,24 +83,16 @@ contract CreditConfigurator is ICreditConfigurator, ACLTrait {
             .addressProvider(); // F:[CC-1]
 
         {
-            address currentConfigurator = creditManager.creditConfigurator();
+            address currentConfigurator = creditManager.creditConfigurator(); // F: [CC-41]
 
             if (currentConfigurator != address(this)) {
                 address[] memory allowedContractsPrev = CreditConfigurator(
                     currentConfigurator
-                ).allowedContracts();
+                ).allowedContracts(); // F: [CC-41]
 
                 uint256 allowedContractsLen = allowedContractsPrev.length;
                 for (uint256 i = 0; i < allowedContractsLen; ) {
-                    if (
-                        creditManager.contractToAdapter(
-                            allowedContractsPrev[i]
-                        ) == address(0)
-                    ) {
-                        revert ContractIsNotAnAllowedTargetException();
-                    }
-
-                    allowedContractsSet.add(allowedContractsPrev[i]);
+                    allowedContractsSet.add(allowedContractsPrev[i]); // F: [CC-41]
 
                     unchecked {
                         ++i;

--- a/contracts/credit/CreditConfigurator.sol
+++ b/contracts/credit/CreditConfigurator.sol
@@ -24,7 +24,7 @@ import { IPoolService } from "../interfaces/IPoolService.sol";
 import { IAddressProvider } from "../interfaces/IAddressProvider.sol";
 
 // EXCEPTIONS
-import { ZeroAddressException, AddressIsNotContractException, IncorrectPriceFeedException, IncorrectTokenContractException } from "../interfaces/IErrors.sol";
+import { ZeroAddressException, AddressIsNotContractException, IncorrectPriceFeedException, IncorrectTokenContractException, CallerNotPausableAdminException, CallerNotUnPausableAdminException } from "../interfaces/IErrors.sol";
 import { ICreditManagerV2, ICreditManagerV2Exceptions } from "../interfaces/ICreditManagerV2.sol";
 
 /// @title CreditConfigurator
@@ -82,6 +82,8 @@ contract CreditConfigurator is ICreditConfigurator, ACLTrait {
         addressProvider = IPoolService(_creditManager.poolService())
             .addressProvider(); // F:[CC-1]
 
+        if (opts.skipInit) return;
+
         /// Sets limits, fees and fastCheck parameters for the Credit Manager
         _setParams(
             DEFAULT_FEE_INTEREST,
@@ -120,6 +122,34 @@ contract CreditConfigurator is ICreditConfigurator, ACLTrait {
         ); // F:[CC-1]
 
         _setLimits(opts.minBorrowedAmount, opts.maxBorrowedAmount); // F:[CC-1]
+    }
+
+    /// @dev Migration function used to populate the new CC's allowedContractsSet based on the previous CC's values
+    /// @param allowedContractsPrev List of allowed contracts to migrate
+    /// @notice Only callable once
+    function migrateAllowedContractsSet(address[] calldata allowedContractsPrev)
+        external
+        configuratorOnly
+    {
+        if (allowedContractsSet.length() != 0) {
+            revert MigratableParameterAlreadySet();
+        }
+
+        uint256 len = allowedContractsPrev.length;
+        for (uint256 i = 0; i < len; ) {
+            if (
+                creditManager.contractToAdapter(allowedContractsPrev[i]) ==
+                address(0)
+            ) {
+                revert ContractIsNotAnAllowedTargetException();
+            }
+
+            allowedContractsSet.add(allowedContractsPrev[i]);
+
+            unchecked {
+                ++i;
+            }
+        }
     }
 
     //
@@ -183,8 +213,8 @@ contract CreditConfigurator is ICreditConfigurator, ACLTrait {
         if (token == underlying) revert SetLTForUnderlyingException(); // F:[CC-5]
 
         (, uint16 ltUnderlying) = creditManager.collateralTokens(0);
-        // Sanity checks for the liquidation threshold. It should be > 0 and less than the LT of the underlying
-        if (liquidationThreshold == 0 || liquidationThreshold > ltUnderlying)
+        // Sanity check for the liquidation threshold. The LT should be less than underlying
+        if (liquidationThreshold > ltUnderlying)
             revert IncorrectLiquidationThresholdException(); // F:[CC-5]
 
         uint16 currentLT = creditManager.liquidationThresholds(token);
@@ -304,6 +334,14 @@ contract CreditConfigurator is ICreditConfigurator, ACLTrait {
         if (creditManager.adapterToContract(adapter) != address(0))
             revert AdapterUsedTwiceException(); // F:[CC-14]
 
+        // If there is an existing adapter for the target contract, it has to be removed
+        address currentAdapter = creditManager.contractToAdapter(
+            targetContract
+        );
+        if (currentAdapter != address(0)) {
+            creditManager.changeContractAllowance(currentAdapter, address(0));
+        }
+
         // Sets a link between adapter and targetContract in creditFacade and creditManager
         creditManager.changeContractAllowance(adapter, targetContract); // F:[CC-15]
 
@@ -340,6 +378,26 @@ contract CreditConfigurator is ICreditConfigurator, ACLTrait {
         allowedContractsSet.remove(targetContract); // F:[CC-17]
 
         emit ContractForbidden(targetContract); // F:[CC-17]
+    }
+
+    /// @dev Removes the link between passed adapter and its contract
+    ///      Useful to remove "orphaned" adapters, i.e. adapters that were replaced but still point
+    ///      to the contract for some reason. This allows users to still execute actions through the old adapter,
+    ///      even though that is not intended.
+    function forbidAdapter(address adapter) external override configuratorOnly {
+        /// Sanity check that zero address was not passed
+        if (adapter == address(0)) revert ZeroAddressException();
+
+        /// If the adapter already has no linked target contract, then there is nothing to change
+        address targetContract = creditManager.adapterToContract(adapter);
+        if (targetContract == address(0)) {
+            revert ContractIsNotAnAllowedAdapterException();
+        }
+
+        /// Removes the adapter => target contract link only
+        creditManager.changeContractAllowance(adapter, address(0));
+
+        emit AdapterForbidden(adapter);
     }
 
     //
@@ -602,10 +660,12 @@ contract CreditConfigurator is ICreditConfigurator, ACLTrait {
     /// @dev Enables or disables borrowing
     /// In Credit Facade (and, consequently, the Credit Manager)
     /// @param _mode Prohibits borrowing if true, and allows borrowing otherwise
-    function setIncreaseDebtForbidden(bool _mode)
-        external
-        configuratorOnly // F:[CC-2]
-    {
+    function setIncreaseDebtForbidden(bool _mode) external {
+        if (_mode && !_acl.isPausableAdmin(msg.sender))
+            revert CallerNotPausableAdminException();
+        else if (!_mode && !_acl.isUnpausableAdmin(msg.sender))
+            revert CallerNotUnPausableAdminException();
+
         _setIncreaseDebtForbidden(_mode);
     }
 

--- a/contracts/interfaces/ICreditConfigurator.sol
+++ b/contracts/interfaces/ICreditConfigurator.sol
@@ -27,8 +27,6 @@ struct CreditManagerOpts {
     address degenNFT;
     /// @dev Whether the Credit Manager is connected to an expirable pool (and the CreditFacade is expirable)
     bool expirable;
-    /// @dev Whether to skip normal initialization - used for new Credit Configurators that are deployed for existing CMs
-    bool skipInit;
 }
 
 interface ICreditConfiguratorEvents {
@@ -133,9 +131,6 @@ interface ICreditConfiguratorExceptions {
 
     /// @dev Thrown if attempting to forbid or migrate a target contract that is not allowed for the Credit Manager
     error ContractIsNotAnAllowedTargetException();
-
-    /// @dev Thrown if attempting to set a migratable parameter that is already non-zero
-    error MigratableParameterAlreadySet();
 }
 
 interface ICreditConfigurator is
@@ -143,16 +138,6 @@ interface ICreditConfigurator is
     ICreditConfiguratorExceptions,
     IVersion
 {
-    //
-    // PARAMETER MIGRATION FUNCTIONS
-    //
-
-    /// @dev Migration function used to populate the new CC's allowedContractsSet based on the previous CC's values
-    /// @param allowedContractsPrev List of allowed contracts to migrate
-    /// @notice Only callable once
-    function migrateAllowedContractsSet(address[] calldata allowedContractsPrev)
-        external;
-
     //
     // STATE-CHANGING FUNCTIONS
     //

--- a/contracts/interfaces/ICreditConfigurator.sol
+++ b/contracts/interfaces/ICreditConfigurator.sol
@@ -27,6 +27,8 @@ struct CreditManagerOpts {
     address degenNFT;
     /// @dev Whether the Credit Manager is connected to an expirable pool (and the CreditFacade is expirable)
     bool expirable;
+    /// @dev Whether to skip normal initialization - used for new Credit Configurators that are deployed for existing CMs
+    bool skipInit;
 }
 
 interface ICreditConfiguratorEvents {
@@ -47,6 +49,9 @@ interface ICreditConfiguratorEvents {
 
     /// @dev Emits when a 3rd-party contract is forbidden
     event ContractForbidden(address indexed protocol);
+
+    /// @dev Emits when a particular adapter for a target contract is forbidden
+    event AdapterForbidden(address indexed adapter);
 
     /// @dev Emits when debt principal limits are changed
     event LimitsUpdated(uint256 minBorrowedAmount, uint256 maxBorrowedAmount);
@@ -125,6 +130,12 @@ interface ICreditConfiguratorExceptions {
 
     /// @dev Thrown if attempting to forbid an adapter that is not allowed for the Credit Manager
     error ContractIsNotAnAllowedAdapterException();
+
+    /// @dev Thrown if attempting to forbid or migrate a target contract that is not allowed for the Credit Manager
+    error ContractIsNotAnAllowedTargetException();
+
+    /// @dev Thrown if attempting to set a migratable parameter that is already non-zero
+    error MigratableParameterAlreadySet();
 }
 
 interface ICreditConfigurator is
@@ -132,6 +143,16 @@ interface ICreditConfigurator is
     ICreditConfiguratorExceptions,
     IVersion
 {
+    //
+    // PARAMETER MIGRATION FUNCTIONS
+    //
+
+    /// @dev Migration function used to populate the new CC's allowedContractsSet based on the previous CC's values
+    /// @param allowedContractsPrev List of allowed contracts to migrate
+    /// @notice Only callable once
+    function migrateAllowedContractsSet(address[] calldata allowedContractsPrev)
+        external;
+
     //
     // STATE-CHANGING FUNCTIONS
     //
@@ -168,6 +189,11 @@ interface ICreditConfigurator is
     /// @dev Forbids contract as a target for calls from Credit Accounts
     /// @param targetContract Address of a contract to be forbidden
     function forbidContract(address targetContract) external;
+
+    /// @dev Forbids adapter (and only the adapter - the target contract is not affected)
+    /// @param adapter Address of adapter to disable
+    /// @notice Used to clean up orphaned adapters
+    function forbidAdapter(address adapter) external;
 
     /// @dev Sets borrowed amount limits in Credit Facade
     /// @param _minBorrowedAmount Minimum borrowed amount

--- a/contracts/interfaces/ICreditConfigurator.sol
+++ b/contracts/interfaces/ICreditConfigurator.sol
@@ -128,9 +128,6 @@ interface ICreditConfiguratorExceptions {
 
     /// @dev Thrown if attempting to forbid an adapter that is not allowed for the Credit Manager
     error ContractIsNotAnAllowedAdapterException();
-
-    /// @dev Thrown if attempting to forbid or migrate a target contract that is not allowed for the Credit Manager
-    error ContractIsNotAnAllowedTargetException();
 }
 
 interface ICreditConfigurator is

--- a/contracts/interfaces/adapters/IAdapter.sol
+++ b/contracts/interfaces/adapters/IAdapter.sol
@@ -34,9 +34,6 @@ interface IAdapter is IAdapterExceptions {
     /// @dev Returns the Credit Manager connected to the adapter
     function creditManager() external view returns (ICreditManagerV2);
 
-    /// @dev Returns the Credit Facade connected to the adapter's Credit Manager
-    function creditFacade() external view returns (address);
-
     /// @dev Returns the address of the contract the adapter is interacting with
     function targetContract() external view returns (address);
 

--- a/contracts/test/config/CreditConfig.sol
+++ b/contracts/test/config/CreditConfig.sol
@@ -61,8 +61,7 @@ contract CreditConfig is DSTest, ICreditConfig {
                 maxBorrowedAmount: maxBorrowedAmount,
                 collateralTokens: getCollateralTokens(),
                 degenNFT: address(0),
-                expirable: false,
-                skipInit: false
+                expirable: false
             });
     }
 

--- a/contracts/test/config/CreditConfig.sol
+++ b/contracts/test/config/CreditConfig.sol
@@ -61,7 +61,8 @@ contract CreditConfig is DSTest, ICreditConfig {
                 maxBorrowedAmount: maxBorrowedAmount,
                 collateralTokens: getCollateralTokens(),
                 degenNFT: address(0),
-                expirable: false
+                expirable: false,
+                skipInit: false
             });
     }
 

--- a/contracts/test/credit/CreditConfigurator.t.sol
+++ b/contracts/test/credit/CreditConfigurator.t.sol
@@ -9,6 +9,8 @@ import { CreditManager } from "../../credit/CreditManager.sol";
 import { CreditConfigurator, CreditManagerOpts, CollateralToken } from "../../credit/CreditConfigurator.sol";
 import { ICreditManagerV2, ICreditManagerV2Events } from "../../interfaces/ICreditManagerV2.sol";
 import { ICreditConfiguratorEvents } from "../../interfaces/ICreditConfigurator.sol";
+import { IAdapter } from "../../interfaces/adapters/IAdapter.sol";
+import { UniversalAdapter } from "../../adapters/UniversalAdapter.sol";
 
 //
 import { PercentageMath, PERCENTAGE_FACTOR, PERCENTAGE_FACTOR } from "../../libraries/PercentageMath.sol";
@@ -17,7 +19,7 @@ import { AddressList } from "../../libraries/AddressList.sol";
 
 // EXCEPTIONS
 import { ICreditConfiguratorExceptions } from "../../interfaces/ICreditConfigurator.sol";
-import { ZeroAddressException, AddressIsNotContractException, CallerNotConfiguratorException, IncorrectPriceFeedException, IncorrectTokenContractException } from "../../interfaces/IErrors.sol";
+import { ZeroAddressException, AddressIsNotContractException, CallerNotConfiguratorException, IncorrectPriceFeedException, IncorrectTokenContractException, CallerNotPausableAdminException, CallerNotUnPausableAdminException } from "../../interfaces/IErrors.sol";
 import { ICreditManagerV2Exceptions } from "../../interfaces/ICreditManagerV2.sol";
 
 // TEST
@@ -145,7 +147,6 @@ contract CreditConfiguratorTest is
 
         /*
         NOTE: How to call create2
-
         create2(v, p, n, s)
         create new contract with code at memory p to p + n
         and send v wei
@@ -364,7 +365,8 @@ contract CreditConfiguratorTest is
             maxBorrowedAmount: uint128(150000 * WAD),
             collateralTokens: cTokens,
             degenNFT: address(0),
-            expirable: false
+            expirable: false,
+            skipInit: false
         });
 
         creditManager = new CreditManager(address(cct.poolMock()));
@@ -470,12 +472,25 @@ contract CreditConfiguratorTest is
         creditConfigurator.upgradeCreditConfigurator(DUMB_ADDRESS);
 
         evm.expectRevert(CallerNotConfiguratorException.selector);
-        creditConfigurator.setIncreaseDebtForbidden(false);
-
-        evm.expectRevert(CallerNotConfiguratorException.selector);
         creditConfigurator.setLimitPerBlock(0);
 
         evm.stopPrank();
+    }
+
+    function test_CC_02A_setIncreaseDebtForbidden_reverts_on_non_pausable_unpausable_admin()
+        public
+    {
+        evm.expectRevert(CallerNotPausableAdminException.selector);
+        creditConfigurator.setIncreaseDebtForbidden(true);
+
+        evm.expectRevert(CallerNotUnPausableAdminException.selector);
+        creditConfigurator.setIncreaseDebtForbidden(false);
+
+        evm.prank(CONFIGURATOR);
+        creditConfigurator.setIncreaseDebtForbidden(true);
+
+        evm.prank(CONFIGURATOR);
+        creditConfigurator.setIncreaseDebtForbidden(false);
     }
 
     //
@@ -558,9 +573,6 @@ contract CreditConfiguratorTest is
         creditConfigurator.setLiquidationThreshold(underlying, 1);
 
         address usdcToken = tokenTestSuite.addressOf(Tokens.USDC);
-
-        evm.expectRevert(IncorrectLiquidationThresholdException.selector);
-        creditConfigurator.setLiquidationThreshold(usdcToken, 0);
 
         uint16 maxAllowedLT = creditManager.liquidationThresholds(underlying);
         evm.expectRevert(IncorrectLiquidationThresholdException.selector);
@@ -795,10 +807,8 @@ contract CreditConfiguratorTest is
         evm.stopPrank();
     }
 
-    /// @dev [CC-14]: allowContract: adapter or contract could not be used twice
-    function test_CC_14_allowContract_reverts_for_creditManager_and_creditFacade_contracts()
-        public
-    {
+    /// @dev [CC-14]: allowContract: adapter could not be used twice
+    function test_CC_14_allowContract_adapter_cannot_be_used_twice() public {
         evm.startPrank(CONFIGURATOR);
 
         creditConfigurator.allowContract(
@@ -858,6 +868,40 @@ contract CreditConfiguratorTest is
         assertTrue(
             allowedContracts.includes(TARGET_CONTRACT),
             "Target contract wasnt found"
+        );
+    }
+
+    /// @dev [CC-15A]: allowContract removes existing adapter
+    function test_CC_15A_allowContract_removes_old_adapter_if_it_exists()
+        public
+    {
+        evm.prank(CONFIGURATOR);
+        creditConfigurator.allowContract(TARGET_CONTRACT, address(adapter1));
+
+        AdapterMock adapter2 = new AdapterMock(
+            address(creditManager),
+            TARGET_CONTRACT
+        );
+
+        evm.prank(CONFIGURATOR);
+        creditConfigurator.allowContract(TARGET_CONTRACT, address(adapter2));
+
+        assertEq(
+            creditManager.contractToAdapter(TARGET_CONTRACT),
+            address(adapter2),
+            "Incorrect adapter"
+        );
+
+        assertEq(
+            creditManager.adapterToContract(address(adapter2)),
+            TARGET_CONTRACT,
+            "Incorrect target contract for new adapter"
+        );
+
+        assertEq(
+            creditManager.adapterToContract(address(adapter1)),
+            address(0),
+            "Old adapter was not removed"
         );
     }
 
@@ -1514,7 +1558,7 @@ contract CreditConfiguratorTest is
     }
 
     /// @dev [CC-39]: removeEmergencyLiquidator works correctly and emits event
-    function test_CC_38_removeEmergencyLiquidator_works_correctly() public {
+    function test_CC_39_removeEmergencyLiquidator_works_correctly() public {
         evm.expectRevert(CallerNotConfiguratorException.selector);
         creditConfigurator.removeEmergencyLiquidator(DUMB_ADDRESS);
 
@@ -1531,5 +1575,81 @@ contract CreditConfiguratorTest is
             !creditManager.canLiquidateWhilePaused(DUMB_ADDRESS),
             "Credit manager emergency liquidator status incorrect"
         );
+    }
+
+    /// @dev [CC-40]: forbidAdapter works correctly and emits event
+    function test_CC_40_forbidAdapter_works_correctly() public {
+        evm.expectRevert(CallerNotConfiguratorException.selector);
+        creditConfigurator.forbidAdapter(DUMB_ADDRESS);
+
+        evm.prank(CONFIGURATOR);
+        creditConfigurator.allowContract(TARGET_CONTRACT, address(adapter1));
+
+        evm.expectEmit(true, false, false, false);
+        emit AdapterForbidden(address(adapter1));
+
+        evm.prank(CONFIGURATOR);
+        creditConfigurator.forbidAdapter(address(adapter1));
+
+        assertEq(
+            creditManager.adapterToContract(address(adapter1)),
+            address(0),
+            "Adapter to contract link was not removed"
+        );
+
+        assertEq(
+            creditManager.contractToAdapter(TARGET_CONTRACT),
+            address(adapter1),
+            "Contract to adapter link was removed"
+        );
+    }
+
+    /// @dev [CC-41]: migrateAllowedContractsSet works correctly
+    function test_CC_41_migrateAllowedContractsSet_works_correctly() public {
+        evm.prank(CONFIGURATOR);
+        creditConfigurator.allowContract(TARGET_CONTRACT, address(adapter1));
+
+        CollateralToken[] memory cTokens;
+
+        CreditManagerOpts memory creditOpts = CreditManagerOpts({
+            minBorrowedAmount: uint128(50 * WAD),
+            maxBorrowedAmount: uint128(150000 * WAD),
+            collateralTokens: cTokens,
+            degenNFT: address(0),
+            expirable: false,
+            skipInit: true
+        });
+
+        CreditConfigurator newCC = new CreditConfigurator(
+            creditManager,
+            creditFacade,
+            creditOpts
+        );
+
+        address[] memory allowedContracts = creditConfigurator
+            .allowedContracts();
+
+        {
+            address[] memory allowedContractsFalse = new address[](2);
+            allowedContractsFalse[0] = allowedContracts[0];
+            allowedContractsFalse[1] = DUMB_ADDRESS;
+
+            evm.expectRevert(ContractIsNotAnAllowedTargetException.selector);
+            evm.prank(CONFIGURATOR);
+            newCC.migrateAllowedContractsSet(allowedContractsFalse);
+        }
+
+        evm.prank(CONFIGURATOR);
+        newCC.migrateAllowedContractsSet(allowedContracts);
+
+        assertEq(
+            creditConfigurator.allowedContracts().length,
+            newCC.allowedContracts().length,
+            "Incorrect new allowed contracts array"
+        );
+
+        evm.expectRevert(MigratableParameterAlreadySet.selector);
+        evm.prank(CONFIGURATOR);
+        newCC.migrateAllowedContractsSet(allowedContracts);
     }
 }


### PR DESCRIPTION
Credit Configurator:
- allowContract now removes the adapterToContract record for previous adapter if it existed
- forbidAdapter was added to clean up adapter records that remained due to above bug
- setLiquidationThreshold now allows setting LT = 0
- a function is added to migrate the allowed contract set and a flag can be passed in the constructor to skip the initial setup; these changes now allow to correctly update the CC
- setIncreaseDebtForbidden is now controlled by pausable admin

AbstractAdapter:
- AbstractAdapter now retrieves creditFacade from CreditManager, which enables correct handling of CF updates